### PR TITLE
Allow jobs to perform a pre-run check and be requeued

### DIFF
--- a/models/queued_task.php
+++ b/models/queued_task.php
@@ -173,6 +173,23 @@ class QueuedTask extends AppModel {
 	}
 
 	/**
+	 * Requeue a job without incrementing its failure count. Used when a job could not be attempted.
+	 *
+	 * @param integer $id
+	 * @param integer $timeout Number of seconds to wait before trying this job again.
+	 */
+	public function requeueJob($id, $timeout) {
+		$db =& $this->getDataSource();
+		return ($this->updateAll(array(
+			'fetched' => null,
+			'workerkey' => null,
+			'notbefore' => 'DATE_ADD(NOW(), INTERVAL ' . intval($timeout) . ' SECOND)'
+		), array(
+			'id' => $id
+		)));
+	}
+
+	/**
 	 * Returns the number of items in the Queue.
 	 * Either returns the number of ALL pending tasks, or the number of pending tasks of the passed Type
 	 *


### PR DESCRIPTION
There are intstances (for example when an account is in maintenance mode) that
it would be unwise to actually perform a queued task. Only the task knows what
those conditions are for itself, so we delegate the job of knowing that to the
task in the canRun() method.

But now we have three outcomes for a job: Done, Failed, and Couldn't run. Add a
new method to the QueuedTask Model to support requeuing a job that isn't
failed.
