### PR TITLE
When we requeued the task, the `notbefore` date was calculated relative

### DIFF
--- a/Model/QueuedTask.php
+++ b/Model/QueuedTask.php
@@ -214,7 +214,7 @@ class QueuedTask extends AppModel {
 		return ($this->updateAll(array(
 			'fetched' => null,
 			'workerkey' => null,
-			'notbefore' => 'DATE_ADD(NOW(), INTERVAL ' . intval($timeout) . ' SECOND)'
+			'notbefore' => "'". date('Y-m-d H:i:s', time() + $timeout) ."'"
 		), array(
 			'id' => $id
 		)));


### PR DESCRIPTION
to the MySQL clock and this is out of sync with PHP's clock. So it was
setting `notbefore` to the past and the job would just get run over and
over again. Now the dates calculated are all by PHP

[delivers #51178479]

Testing Notes:
To create the issue, create a RemoveAccountUser job in the queue (Delete or terminate user). Make it doesn't run yet. Turn maintenance mode on for the account then start the queue. This should, without this PR, just continually run the job. 

To get new code:
1) Delete `Plugin/CakephpQueue` folder
2) Delete `app/composer.lock`
3) Run `php ../composer.phar install` from app directory

Expected Result:
The job should be requeued from 2 minutes from when it was fetched.
