### PR TITLE
[WEB-6233] Ensure parent Shell initialize is called to load models and tasks.

### DIFF
--- a/Console/Command/QueueShell.php
+++ b/Console/Command/QueueShell.php
@@ -49,7 +49,6 @@ class QueueShell extends Shell {
 	 */
 	public function initialize() {
 		App::import('Folder');
-		$this->_loadModels();
 		
 		foreach (App::path('shells') as $path) {
 			$folder = new Folder($path . DS . 'Task');
@@ -81,6 +80,8 @@ class QueueShell extends Shell {
 		if(isset($this->params['-verbose'])) {
 			$this->_verbose = true;
 		}
+
+		parent::initialize();
 	}
 
 	/**

--- a/Model/QueuedTask.php
+++ b/Model/QueuedTask.php
@@ -168,7 +168,7 @@ class QueuedTask extends AppModel {
 					'workerkey' => $key
 				)
 			));
-			if (is_array($data)) {
+			if (is_array($data) && !empty($data)) {
 				// if the job had an existing fetched timestamp, increment the failure counter
 				if (in_array($data[$this->name]['id'], $wasFetched)) {
 					$data[$this->name]['failed']++;


### PR DESCRIPTION
Ensure parent Shell initialize is called to load models and tasks. A change was made in CakePHP > 2.0.1 (specific version unknown due to lack of caring), this moved loading of tasks into the Shell initialize method instead of ShellDispatcher::dispatch(). Since CakephpQueue overrides Shell::initialize and didn't call the parent method we no longer had tasks loaded and were unable to process any QueuedTasks.

In my debugging I had modified the QueuedTasks table and set workerkey to '' instead of NULL, this caused a crash in the queue, so I made this code a bit more robust.

*NOTE:* To test you will have to composer reload or update or something....

*** Testing Notes ***

If the queue is able to process tasks then this is fixed, as it was the dispatching of tasks that was affected. Note if you have a queue already running you need to restart it when switching branches.