### PR TITLE
[WEB-7003] Queue Status Monitor Plugin Commands

### DIFF
--- a/Console/Command/QueueShell.php
+++ b/Console/Command/QueueShell.php
@@ -359,8 +359,7 @@ class QueueShell extends Shell {
 	 */
 	private function sendToHipchat($message) {
 		$hipchatToken = 'c7cdab9bff9a7e0aae766aea345334';
-		// $hipchatRoomID = '84232'; // Scrum: TribeHR
-		$hipchatRoomID = '2124722'; // QueueMinder Test
+		$hipchatRoomID = QUEUE_MONITOR_HIPCHAT_ROOM;
 		$fromName = 'Queue Monitor';
 		$notify = 1;
 		$color = 'yellow';

--- a/Console/Command/QueueShell.php
+++ b/Console/Command/QueueShell.php
@@ -307,7 +307,10 @@ class QueueShell extends Shell {
 	private function writeFile($info) {
 		App::import('File');
 		$file = new File(QUEUE_MONITOR_OUTFILE);
-		$file->write('readJson(' . json_encode($info) . ")\n", $mode = 'w', $force = true);
+		if (!$file->write('readJson(' . json_encode($info) . ")\n", $mode = 'w', $force = true)) {
+			$this->out('Unable to write JSONP file.');
+			CakeLog::error('CakephpQueue Monitor: Unable to write JSONP file.');
+		}
 		$file->close();
 		$this->out('File written to: ' . QUEUE_MONITOR_OUTFILE);
 	}
@@ -328,7 +331,7 @@ class QueueShell extends Shell {
 	/**
 	 * Make sure we aren't sending the same message over and over.
 	 *
-	 * @return boolean true if we are not spamming, false if we don't want.
+	 * @return boolean true if we are not spamming, false if we do not want to send message.
 	 */
 	private function spamCheck() {
 		App::import('File');
@@ -339,13 +342,13 @@ class QueueShell extends Shell {
 				$this->out('Alert triggered, but on cooldown.');
 				return false;
 			}
-			$file->write(date('c'), $mode = 'w', $force = true);
-			return true;
-		} else {
-			$file->write(date('c'), $mode = 'w', $force = true);
+		}
+		if ($file->write(date('c'), $mode = 'w', $force = true)) {
 			return true;
 		}
-		$this->out('Something went wrong with spam protection.');
+		$this->out('Unable to write spam protection file.');
+		CakeLog::error('CakephpQueue Monitor: Unable to write spam protection file.');
+		// if we can't write to the file, we can't send the alert because we could be spamming.
 		return false;
 	}
 
@@ -415,7 +418,7 @@ class QueueShell extends Shell {
 	
 	function out($str = null, $newlines = 1, $level = Shell::NORMAL) {
 		$str = date('Y-m-d H:i:s').' '.$str;
-		return parent::out($str, $newlines, $level);
+		return parent::out($str);
 	}
 
 	function _exit($signal) {

--- a/Console/Command/QueueShell.php
+++ b/Console/Command/QueueShell.php
@@ -10,6 +10,8 @@ declare(ticks = 1);
  */
 
 App::uses('Folder', 'Utility');
+App::uses('File', 'Utility');
+App::import('Vendor', 'Hipchat', array('file' => 'HipchatPhp/src/HipChat/HipChat.php')); 
 
 class QueueShell extends Shell {
 	public $uses = array(
@@ -27,6 +29,9 @@ class QueueShell extends Shell {
 	protected $_verbose = false;
 
 	private $exit;
+
+	const ALERT_SIZE = 100;
+	const ALERT_COOLDOWN = 1800;
 
 
 	function getOptionParser() {
@@ -250,6 +255,123 @@ class QueueShell extends Shell {
 	}
 
 	/**
+	 * Write the status of the queue out to the terminal.
+	 * @return null
+	 */
+	public function status() {
+		$info = $this->getStatus();
+		$this->out('Queue size: ' . $info['queue_size']);
+		$this->out('Last Task Completed: ' . $info['last_task_completed']);
+	}
+
+	/**
+	 * To be called periodically by a task scheduler like Cron. Writes the queue status to a file and 
+	 * sends an alert if it meets certain warning conditions.
+	 *
+	 * @return null
+	 */
+	public function statusFile() {
+		$info = $this->getStatus();
+		if ($info['status'] == 'bad') {
+			$this->sendAlert($info);
+		}
+		$this->writeFile($info);	
+	}
+
+	/**
+	 * Fetch the status from the queue database and put data in an array the different output functions can use.
+	 *
+	 * @return array Keyed array of metrics we want from the queue.
+	 */
+	private function getStatus() {
+		$info['queue_size'] = $this->QueuedTask->getPending();
+		$lastTask = $this->QueuedTask->getLastCompleted();
+		if (!empty($lastTask)) {
+			$info['last_task_completed'] = $lastTask['QueuedTask']['completed'];
+		} else {
+			$info['last_task_completed'] = null;
+		}
+		$info['status'] = 'good';
+		if ($info['queue_size'] > self::ALERT_SIZE) {
+			$info['status'] = 'bad';
+		}
+		return $info;
+	}
+
+	/**
+	 * Write the output of status() to a selected file path.
+	 * Where the file is written is defined in app/Config/bootstrap.{environment}.php
+	 *
+	 * @param array $info The values to output
+	 */
+	private function writeFile($info) {
+		App::import('File');
+		$file = new File(QUEUE_MONITOR_OUTFILE);
+		$file->write('readJson(' . json_encode($info) . ")\n", $mode = 'w', $force = true);
+		$file->close();
+		$this->out('File written to: ' . QUEUE_MONITOR_OUTFILE);
+	}
+	
+	/**
+	 * Send Alert.  This could be an email or message to HipChat.
+	 * For this version it goes to HipChat
+	 * 
+	 * @param array $info Array of queue info.
+	 */
+	private function sendAlert($info) {
+		if ($this->spamCheck()) {
+			$this->sendToHipchat(ENVIRONMENT . ' -- Queue has ' . $info['queue_size'] . ' pending items.');
+			$this->out('Alert triggered.');
+		}
+	}
+
+	/**
+	 * Make sure we aren't sending the same message over and over.
+	 *
+	 * @return boolean true if we are not spamming, false if we don't want.
+	 */
+	private function spamCheck() {
+		App::import('File');
+		$file = new File('tmp/queue_last_alert.txt');
+		if ($file->exists()) {
+			$last_alert = strtotime($file->read());
+			if ((time() - $last_alert) < self::ALERT_COOLDOWN) {
+				$this->out('Alert triggered, but on cooldown.');
+				return false;
+			}
+			$file->write(date('c'), $mode = 'w', $force = true);
+			return true;
+		} else {
+			$file->write(date('c'), $mode = 'w', $force = true);
+			return true;
+		}
+		$this->out('Something went wrong with spam protection.');
+		return false;
+	}
+
+	/**
+	 * Sends the message to HipChat
+	 *
+	 * @param string The message you want to send
+	 */
+	private function sendToHipchat($message) {
+		$hipchatToken = 'c7cdab9bff9a7e0aae766aea345334';
+		// $hipchatRoomID = '84232'; // Scrum: TribeHR
+		$hipchatRoomID = '2124722'; // QueueMinder Test
+		$fromName = 'Queue Monitor';
+		$notify = 1;
+		$color = 'yellow';
+
+		$hipchatConnection = new HipChat\HipChat($hipchatToken);
+		try {
+			$result = $hipchatConnection->message_room($hipchatRoomID, $fromName, $message, $notify, $color);
+		} catch (HipChat\HipChat_Exception $e) {
+			$this->out("Failed to alert to hipchat: " . $e->getMessage());				
+			$result = false;
+		}
+	}
+
+	/**
 	 * Returns a List of available QueueTasks and their individual configurations.
 	 * @return array
 	 */
@@ -291,7 +413,7 @@ class QueueShell extends Shell {
 		}
 	}
 	
-	function out($str='') {
+	function out($str = null, $newlines = 1, $level = Shell::NORMAL) {
 		$str = date('Y-m-d H:i:s').' '.$str;
 		return parent::out($str);
 	}
@@ -301,4 +423,4 @@ class QueueShell extends Shell {
 	}
 
 }
-?>
+

--- a/Console/Command/QueueShell.php
+++ b/Console/Command/QueueShell.php
@@ -416,8 +416,10 @@ class QueueShell extends Shell {
 	}
 	
 	function out($str = null, $newlines = 1, $level = Shell::NORMAL) {
-		$str = date('Y-m-d H:i:s').' '.$str;
-		return parent::out($str);
+		if ($newlines > 0) {
+			$str = date('Y-m-d H:i:s').' '.$str;
+		}
+		return parent::out($str, $newlines, $level);
 	}
 
 	function _exit($signal) {

--- a/Console/Command/QueueShell.php
+++ b/Console/Command/QueueShell.php
@@ -415,7 +415,7 @@ class QueueShell extends Shell {
 	
 	function out($str = null, $newlines = 1, $level = Shell::NORMAL) {
 		$str = date('Y-m-d H:i:s').' '.$str;
-		return parent::out($str);
+		return parent::out($str, $newlines, $level);
 	}
 
 	function _exit($signal) {

--- a/Model/QueuedTask.php
+++ b/Model/QueuedTask.php
@@ -230,6 +230,7 @@ class QueuedTask extends AppModel {
 	 * Either returns the number of ALL pending tasks, or the number of pending tasks of the passed Type
 	 *
 	 * @param string $type jobType to Count
+	 * @param boolean $omitScheduled Whether to count jobs that are waiting for a not_before time to execute.
 	 * @return integer
 	 */
 	public function getLength($type = null) {
@@ -238,9 +239,31 @@ class QueuedTask extends AppModel {
 				'completed' => null
 			)
 		);
+
 		if ($type != NULL) {
 			$findConf['conditions']['jobtype'] = $type;
 		}
+
+		return $this->find('count', $findConf);
+	}
+
+	/**
+	 * Returns the number of items in the Queue.
+	 * Either returns the number of ALL pending tasks, or the number of pending tasks of the passed Type
+	 *
+	 * @param string $type jobType to Count
+	 * @param boolean $omitScheduled Whether to count jobs that are waiting for a not_before time to execute.
+	 * @return integer
+	 */
+	public function getPending() {
+		$findConf = array(
+			'conditions' => array(
+				'completed' => null,
+				'fetched' => null,
+				'notbefore' => null,
+			)
+		);
+
 		return $this->find('count', $findConf);
 	}
 
@@ -346,5 +369,25 @@ class QueuedTask extends AppModel {
 		}
 	
 	}
+
+	/**
+	 * Get the most recently completed task.
+	 *
+	 * @return array A QueuedTask 
+	 */
+	public function getLastCompleted() {
+
+		$query = array(
+			'conditions' => array(
+				'completed IS NOT NULL',
+				),
+			'order' => array(
+				'completed' => 'desc',
+				),
+			);
+
+		return $this->find('first', $query);
+
+	}
 }
-?>
+

--- a/Model/QueuedTask.php
+++ b/Model/QueuedTask.php
@@ -230,7 +230,6 @@ class QueuedTask extends AppModel {
 	 * Either returns the number of ALL pending tasks, or the number of pending tasks of the passed Type
 	 *
 	 * @param string $type jobType to Count
-	 * @param boolean $omitScheduled Whether to count jobs that are waiting for a not_before time to execute.
 	 * @return integer
 	 */
 	public function getLength($type = null) {
@@ -239,7 +238,6 @@ class QueuedTask extends AppModel {
 				'completed' => null
 			)
 		);
-
 		if ($type != NULL) {
 			$findConf['conditions']['jobtype'] = $type;
 		}


### PR DESCRIPTION
Update to check queue size to sniff for a stalled state.
Added method to check only unscheduled, not-failed, pending tasks.

New shell shell commands: status, statusFile

Status just writes some info out to the command line, in case you are on the server and want to check manually.

The CRON should run statusFile repeatedly to write out the queue status to a public readable file.
Your TribeHR repo must be updated to set the QUEUE_MONITOR_OUTFILE constant depending on where you want the file to go!

Writes out a JSONP file of the format:
readJson({"queue_size":23,"last_task_completed":"2015-10-27 18:30:59","status":"good"})